### PR TITLE
Use agent instead of atom to implement mock connection

### DIFF
--- a/src/datomock/impl.clj
+++ b/src/datomock/impl.clj
@@ -88,6 +88,6 @@
   [^Database db, ^Log parent-log]
   (let [state-agent (-> (agent (->MockConnState db [] nil))
                         (add-watch ::force-deliver-promise (fn [_ _ old new]
-                                                             (when-not (= old new)
+                                                             (when-not (identical? old new)
                                                                (force (:deliver-tx-res new))))))]
     (->MockConnection state-agent (d/next-t db) parent-log (atom nil))))

--- a/src/datomock/impl.clj
+++ b/src/datomock/impl.clj
@@ -40,7 +40,11 @@
 
   Connection
   (db [_] (:db @a_state))
-  (transact [_ tx-data]
+  (transact [this tx-data]
+    (let [fut (.transactAsync this tx-data)]
+      (deref fut)
+      fut))
+  (transactAsync [this tx-data]
     (let [fut (datomic.promise/settable-future)]
       (send a_state
             (fn [old-val]
@@ -54,7 +58,6 @@
                     (->MockConnState (:db-after tx-res) (conj (:logVec old-val) (log-item tx-res))))
                 old-val)))
       fut))
-  (transactAsync [this tx-data] (.transact this tx-data))
 
   (requestIndex [_] true)
   (release [_] (do nil))

--- a/test/datomock/core_test.clj
+++ b/test/datomock/core_test.clj
@@ -160,9 +160,31 @@
                      (.syncIndex conn t)
                      (.syncSchema conn t)]]
           (is (instance? ListenableFuture fut))
-          (is (= @fut db)))
-        ))
-    ))
+          (is (= @fut db)))))
+
+(deftest sync-methods
+  (testing "when sync is called with a t, returns a future that acquires a db such that its basisT >= t"
+      (let [conn (dm/mock-conn)
+            _ @(d/transact conn [])
+            requested-t (+ (d/basis-t (d/db conn)) 200)
+            f (d/sync conn requested-t)]
+        ;; empty transactions to increase basisT to requested-t
+        (future
+          (dotimes [_ 200]
+            @(d/transact conn [])))
+        (is (>= (d/basis-t @f) requested-t))
+        (is (future-done? f))))
+
+  (testing "the future returned by sync blocks when called with a t that is not yet available"
+      (let [conn (dm/mock-conn)
+            _ @(d/transact conn [])
+            requested-t (+ (d/basis-t (d/db conn)) 200)
+            f (d/sync conn requested-t)]
+        ;; empty transactions to increase basisT, but not enough to reach requested-t
+        (dotimes [_ 199]
+          @(d/transact conn []))
+        (is (not (future-done? f)) )
+        (is (= :timeout (deref f 10 :timeout)) ))))
 
 (deftest log
   (let [conn (let [uri (str "datomic:mem://" "datomock-" (UUID/randomUUID))]

--- a/test/datomock/core_test.clj
+++ b/test/datomock/core_test.clj
@@ -160,7 +160,7 @@
                      (.syncIndex conn t)
                      (.syncSchema conn t)]]
           (is (instance? ListenableFuture fut))
-          (is (= @fut db)))))
+          (is (= @fut db)))))))
 
 (deftest sync-methods
   (testing "when sync is called with a t, returns a future that acquires a db such that its basisT >= t"


### PR DESCRIPTION
Uses an agent to manage the state of the mock connection, 
see https://github.com/vvvvalvalval/datomock/issues/2