### PR TITLE
Add datomic-pro 1.0.6527 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
-### 0.2.1 - 2018-07-03
+### [0.2.2] - 2018-07-03
 ### Added
 - Testing with test.check
 ### Fixed
@@ -11,26 +11,26 @@ All notable changes to this project will be documented in this file. This change
 ### Removed
 - Tests for Clojure 1.6 - incompatible with test.check
 
-### 0.2.1 - 2018-06-15
+### [0.2.1] - 2018-06-15
 ### Added
 - tests for datomic.api/settable-future.
 ### Fixed
 - datomic.api/transact no longer throws when the transaction fails.
 
-## 0.2.0 - 2017-03-01
+## [0.2.0] - 2017-03-01
 ### Added
 - Log API support
 ### Changed
 - dependencies versions for tests
 
-## 0.1.0 - 2016-02-14
+## [0.1.0] - 2016-02-14
 ### Added
 - mock-conn fn (atom-based implementation of datomic.Connection)
 - fork-conn fn
 - empty-db fn
 - tests
 
-[Unreleased]: https://github.com/vvvvalvalval/datomock/compare/v0.2.2...HEAD
-[0.2.1]: https://github.com/vvvvalvalval/datomock/compare/v0.2.1...0.2.2
-[0.2.1]: https://github.com/vvvvalvalval/datomock/compare/v0.2.0...0.2.1
-[0.2.0]: https://github.com/vvvvalvalval/datomock/compare/v0.1.0...0.2.0
+[Unreleased]: https://github.com/vvvvalvalval/datomock/compare/v.0.2.2...HEAD
+[0.2.2]: https://github.com/vvvvalvalval/datomock/compare/v0.2.1...v.0.2.2
+[0.2.1]: https://github.com/vvvvalvalval/datomock/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/vvvvalvalval/datomock/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ This library requires Datomic 0.9.4470 or higher, in order to provide an impleme
 
 However, if you need to work with a lower version, forking this library and removing the implementation of the `syncSchema()`, `syncExcise()` and `syncIndex()` should work just fine.
 
+This library works with Datomic 1.0.6527, but mock connections do not support
+[transaction io-stats](https://docs.datomic.com/on-prem/api/io-stats.html#transactions).
+A call like `(d/transact mock-conn :io-context true)` will not include an
+`:io-stats` key in the result.
+[Query io-stats](https://docs.datomic.com/on-prem/api/io-stats.html#query)
+are supported insofar as return value shapes will be correct,
+but the underlying Datomic mem database doesn't provide any useful
+information in `:io-stats` `:reads`.
+
 ## License
 
 Copyright © 2016 Valentin Waeselynck and contributors.

--- a/project.clj
+++ b/project.clj
@@ -8,16 +8,21 @@
   :profiles
   {:test {:dependencies [[org.clojure/test.check "0.9.0"]]}
 
-   :dev {:dependencies [[com.datomic/datomic-free "0.9.5561"]
+   :dev {:dependencies [[com.datomic/datomic-free "0.9.5697"]
                         [org.clojure/clojure "1.8.0"]
                         [criterium "0.4.3"]]}
+   :last-datomic-pro
+   {:repositories
+    {"my.datomic.com" {:url "https://my.datomic.com/repo"}}
+    :dependencies
+    [[com.datomic/datomic-pro "1.0.6527"]]}
+
    :last-datomic
-   {:dependencies [[com.datomic/datomic-free "0.9.5561"]
-                   [org.clojure/clojure "1.8.0"]]}
+   {:dependencies [[com.datomic/datomic-free "0.9.5697"]]}
    :oldest-datomic
    {:dependencies [[com.datomic/datomic-free "0.9.4470"]]}
 
    :last-clojure
-   {:dependencies [[:org.clojure/clojure "1.8.0"]]}
+   {:dependencies [[:org.clojure/clojure "1.11.1"]]}
    :clojure7
    {:dependencies [[:org.clojure/clojure "1.7.0"]]}})

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,6 +2,8 @@
 lein with-profile test,last-clojure,oldest-datomic test
 lein with-profile test,last-clojure,last-datomic test
 
-lein with-profile test,clojure7,oldest-datomic test
+# Uncomment if you have a datomic-pro license
+# and access to the dependency via maven.
+#lein with-profile test,last-clojure,last-datomic-pro test
 
-lein with-profile test,clojure6,oldest-datomic test
+lein with-profile test,clojure7,oldest-datomic test

--- a/src/datomock/impl.clj
+++ b/src/datomock/impl.clj
@@ -1,5 +1,6 @@
 (ns datomock.impl
-  (:require [datomic.api :as d]
+  (:require [clojure.reflect :as reflect]
+            [datomic.api :as d]
             [datomic.promise])
   (:import (datomic Log Database Connection)
            (java.util UUID Date)
@@ -69,12 +70,12 @@
           (and (start-pred tx-res) (end-pred tx-res)))))
     (map #(dissoc % :db/txInstant))))
 
-(defn forked-txRange 
+(defn forked-txRange
   [originLog forkT logVec startT endT]
-  (concat 
+  (concat
     (when (some? originLog)
       (->> (d/tx-range originLog startT endT)
-        ;; NOTE we need this additional filtering step because the originLog has been read 
+        ;; NOTE we need this additional filtering step because the originLog has been read
         ;; _after_ reading the starting-point db, leaving time for additional txes to have been added (Val, 01 Jul 2018)
         (filter (fn [{:as tx-res :keys [t]}]
                   (<= t forkT)))))
@@ -113,38 +114,55 @@
           )))
     ))
 
-(defrecord MockConnection
-  [a_state,                                                 ;; an atom, holding a MockConnState
-   forkT,                                                   ;; the basis-t of the starting-point db / connection at the time of forking
-   originLog,                                               ;; a Log Value of the origin connection, taken _after_ derefing its db
-   a_txq                                                    ;; an atom, holding the txReportQueue when it exists
-   ]
+(defn- extended-connection-transact-methods?
+  "Return true if the datomic.Connection interface has the additional
+  transact and transactAsync methods added in datomic 1.0.6527."
+  []
+  (->> (reflect/reflect Connection)
+       :members
+       (filter #(and (= (:name %) 'transactAsync)
+                     (= (:parameter-types %) '[java.util.List java.lang.Object])))
+       seq
+       boolean))
 
-  Connection
-  (db [_] (:db @a_state))
-  (transact [_ tx-data]
-    (transact! a_state a_txq tx-data))
-  (transactAsync [this tx-data] (.transact this tx-data))
+(defmacro ^:private def-MockConnection []
+  `(defrecord ~'MockConnection
+     ~'[a_state,                                               ;; an atom, holding a MockConnState
+        forkT,                                                 ;; the basis-t of the starting-point db / connection at the time of forking
+        originLog,                                             ;; a Log Value of the origin connection, taken _after_ derefing its db
+        a_txq                                                  ;; an atom, holding the txReportQueue when it exists
+        ]
 
-  (requestIndex [_] true)
-  (release [_] (do nil))
-  (gcStorage [_ olderThan] (do nil))
+     ~'Connection
+     ~'(db [_] (:db @a_state))
+     ~'(transact [_ tx-data]
+                 (transact! a_state a_txq tx-data))
+     ~'(transactAsync [this tx-data] (.transact this tx-data))
 
-  (sync [this] (doto (datomic.promise/settable-future)
-                 (deliver (.db this))))
-  (sync [this t] (.sync this))
-  (syncExcise [this t] (.sync this))
-  (syncIndex [this t] (.sync this))
-  (syncSchema [this t] (.sync this))
+     ~@(when (extended-connection-transact-methods?)
+         ['(transact [this tx-data _] (.transact this tx-data))
+          '(transactAsync [this tx-data _] (.transact this tx-data))])
 
-  (txReportQueue [_]
-    (or @a_txq
-        (swap! a_txq #(or % (LinkedBlockingDeque.)))))
-  (removeTxReportQueue [_]
-    (reset! a_txq nil))
+     ~'(requestIndex [_] true)
+     ~'(release [_] (do nil))
+     ~'(gcStorage [_ olderThan] (do nil))
 
-  (log [_] (->ForkedLog originLog forkT (:logVec @a_state)))
-  )
+     ~'(sync [this] (doto (datomic.promise/settable-future)
+                      (deliver (.db this))))
+     ~'(sync [this t] (.sync this))
+     ~'(syncExcise [this t] (.sync this))
+     ~'(syncIndex [this t] (.sync this))
+     ~'(syncSchema [this t] (.sync this))
+
+     ~'(txReportQueue [_]
+                      (or @a_txq
+                          (swap! a_txq #(or % (LinkedBlockingDeque.)))))
+     ~'(removeTxReportQueue [_]
+                            (reset! a_txq nil))
+
+     ~'(log [_] (->ForkedLog originLog forkT (:logVec @a_state)))))
+
+(def-MockConnection)
 
 (defn mock-conn*
   [^Database db, ^Log parent-log]


### PR DESCRIPTION
Datomic 1.0.6527 extended the datomic.Connection interface
with an additional optional parameter on the transact and transactAsync
methods to support the :io-context argument.

datomic.api/transactAsync wrapper calls these new interface methods
even if there are no extra arguments in the clojure call,
which means Datomock doesn't work with Datomic 1.0.6527.

This commit wraps the MockConnection defrecord form in a defmacro which
uses reflection to determine if datomic.Connection has the extra interface
method and conditionally emits an implementation if it does.
We must use a macro and not simply extend-type MockConnection because
datomic.Connection is a true Java interface, not a Clojure protocol.

The implementation ignores extra io-context arguments and just calls
the existing method.
This is enough to get Datomock working, but the transact result will never
have an :io-stats key. This is acceptable because memory db io-stats
are not useful anyway.

I tested this locally and left in the latest-datomic-pro and run-test.sh changes
I used to do so; but you need a recent datomic license to get access
to this version of datomic. These datomic.Connection changes are not
available on any version of datomic-free.

I also bumped the latest-datomic to the latest datomic-free version
and fixed some broken links in the changelog.